### PR TITLE
Compatibility with deltaesp's spanish translation mod

### DIFF
--- a/customdifficulty_installfiles/Scripts/customdifficulty_ch1to4.csx
+++ b/customdifficulty_installfiles/Scripts/customdifficulty_ch1to4.csx
@@ -17,7 +17,7 @@ if (alreadyInstalled != null) {
 }
 
 // Prefire checks
-const string expectedDisplayName = "DELTARUNE Chapter ([1-4])";
+const string expectedDisplayName = "DELTARUNE \\S+ ([1-4])";
 if (!Regex.IsMatch(displayName, expectedDisplayName, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)))
 {
     ScriptError($"Error 0: data file display name does not match expected: '{expectedDisplayName}', actual display name: '{displayName}'.");

--- a/customdifficulty_installfiles/Scripts/modmenu_ch1to4.csx
+++ b/customdifficulty_installfiles/Scripts/modmenu_ch1to4.csx
@@ -19,7 +19,7 @@ if (alreadyInstalled != null) {
 }
 
 // Prefire checks
-const string expectedDisplayName = "DELTARUNE Chapter ([1-4])";
+const string expectedDisplayName = "DELTARUNE \\S+ ([1-4])";
 if (!Regex.IsMatch(displayName, expectedDisplayName, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(500)))
 {
     ScriptError($"Error 0: data file display name does not match expected: '{expectedDisplayName}', actual display name: '{displayName}'.");


### PR DESCRIPTION
This was caused by the data files having their names changed to Spanish. The pre-fire regex now ignores the second word, so any direct language translation should pass the checks.

https://github.com/Emmehehe/CustomDifficultyModForDeltarune/issues/28